### PR TITLE
Support for parameters in url

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -25,7 +25,7 @@ char *get_request_value(char *buf)
 
     if (retval[strlen(retval)-1] == '/')
         strcat(retval, "index.html");
-
+    strtok(retval, "?");
     return strdup(retval);
 }
 


### PR DESCRIPTION
This change removes the part of the url after the question mark so you don't get a 404 error when setting a custom parameter using ?key=value